### PR TITLE
Step 06: Implement PS5-only mod count via mod.io; harden watcher & alerts

### DIFF
--- a/src/mod_alert.py
+++ b/src/mod_alert.py
@@ -1,20 +1,129 @@
 # src/mod_alert.py
 import time
 import argparse
-from .state import load_state, save_state
-from .mailer import send_email
+import os
+from pathlib import Path
 
-# --- still a stub; implement in Step 04 ---
+import requests
+from dotenv import load_dotenv
+
+from src.state import load_state, save_state
+from src.mailer import send_email
+
+# Load .env from the repo root (one level up from /src)
+load_dotenv(Path(__file__).resolve().parents[1] / ".env")
+
+
+def find_games(query: str) -> None:
+    """Search mod.io for games and print ID + slug so you can set MODIO_GAME_ID."""
+    base = os.getenv("MODIO_BASE", "https://api.mod.io/v1")
+    key = os.getenv("MODIO_API_KEY")
+    if not key:
+        raise RuntimeError("Set MODIO_API_KEY in your .env first.")
+    r = requests.get(
+        f"{base}/games",
+        params={"api_key": key, "_q": query, "_limit": 50},  # <- _q is the official search
+        timeout=15,
+        headers={"X-Modio-Platform": (os.getenv("MODIO_PLATFORM") or "ps5").lower()},
+    )
+    r.raise_for_status()
+    for g in r.json().get("data", []):
+        print(f"{g['id']:>8}  {g.get('name')}   (slug: {g.get('name_id')})")
+
+def _resolve_game_id(game_value: str) -> str:
+    """
+    Accepts either a numeric ID or a slug (name_id) like 'baldursgate3'.
+    Returns the numeric ID as a string.
+    """
+    base = os.getenv("MODIO_BASE", "https://api.mod.io/v1")
+    key  = os.getenv("MODIO_API_KEY")
+    headers = {"X-Modio-Platform": (os.getenv("MODIO_PLATFORM") or "ps5").lower()}
+
+    if not key or not game_value:
+        raise RuntimeError("Missing MODIO_API_KEY or MODIO_GAME_ID in .env")
+
+    if game_value.isdigit():
+        return game_value
+
+    r = requests.get(
+        f"{base}/games",
+        params={"api_key": key, "name_id": game_value, "_limit": 1},
+        headers=headers,
+        timeout=15,
+    )
+    r.raise_for_status()
+    data = r.json().get("data", [])
+    if data and data[0].get("name_id") == game_value:
+        return str(data[0]["id"])
+    raise RuntimeError(f"Could not resolve game slug '{game_value}'.")
+
 def get_mod_count() -> int:
-    raise NotImplementedError("Implement get_mod_count() in Step 04.")
+    """
+    Return the PS5-only mod count by calling /games/{id}/mods with X-Modio-Platform: ps5.
+    No unfiltered fallbacks. If we can't get a platform-filtered total, raise RuntimeError.
+    """
+    key  = os.getenv("MODIO_API_KEY")
+    game = (os.getenv("MODIO_GAME_ID") or "").strip()  # slug or numeric
+    plat = (os.getenv("MODIO_PLATFORM") or "ps5").lower()
+    if not key or not game:
+        raise RuntimeError("Missing MODIO_API_KEY or MODIO_GAME_ID in .env")
+
+    headers = {"X-Modio-Platform": plat, "Accept": "application/json"}
+    params  = {"api_key": key, "_limit": 1}
+
+    # Resolve slug -> id (once) via the same hosts we’ll query
+    hosts = [os.getenv("MODIO_BASE") or "https://g-1.modapi.io/v1", "https://api.mod.io/v1"]
+    gid = None
+    if game.isdigit():
+        gid = game
+    else:
+        for base in hosts:
+            try:
+                rr = requests.get(f"{base}/games", params={**params, "name_id": game},
+                                  headers=headers, timeout=15)
+                rr.raise_for_status()
+                items = rr.json().get("data", [])
+                if items:
+                    gid = str(items[0]["id"])
+                    break
+            except Exception:
+                continue
+        if not gid:
+            raise RuntimeError(f"Game '{game}' not found on mod.io")
+
+    # Ask the filtered mods endpoint for result_total
+    last_err = None
+    for base in hosts:
+        try:
+            r = requests.get(f"{base}/games/{gid}/mods", params=params,
+                             headers=headers, timeout=15)
+            if r.status_code == 404:
+                last_err = f"404 at {r.url}"
+                continue
+            r.raise_for_status()
+            data = r.json()
+            total = (data.get("result_total")
+                     or data.get("result_count")
+                     or len(data.get("data", [])))
+            return int(total)
+        except Exception as e:
+            last_err = f"{e}"
+            continue
+
+    raise RuntimeError(f"Could not fetch PS5-only mod count (last error: {last_err})")
+
 
 def run_check():
     state = load_state()
-    current = get_mod_count()  # will raise until implemented
-    last = state["last_count"]
+    try:
+        current = get_mod_count()
+    except RuntimeError as e:
+        print(f"Error fetching PS5 count: {e}")
+        return  # do not change baseline / do not email
 
+    last = state.get("last_count")
     if last is None:
-        state["last_count"] = current  # set baseline on first successful run
+        state["last_count"] = current
     elif current > last:
         diff = current - last
         send_email(
@@ -25,16 +134,26 @@ def run_check():
 
     state["last_checked"] = int(time.time())
     save_state(state)
+    print("PS5 count =", current)
+
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--interval-mins", type=int, default=0,
-                        help="If >0, run forever every N minutes. If 0, run once.")
+    parser.add_argument(
+        "--interval-mins", type=int, default=0,
+        help="If >0, run forever every N minutes. If 0, run once."
+    )
     parser.add_argument("--test-email", action="store_true",
                         help="Send a test email and exit.")
     parser.add_argument("--baseline", type=int,
                         help="Set/override baseline count and exit.")
-    args = parser.parse_args()
+    parser.add_argument("--find-game", type=str,
+                        help="Search mod.io games by name and print IDs.")
+    args = parser.parse_args()  # <- parse BEFORE using args
+
+    if args.find_game:
+        find_games(args.find_game)
+        return
 
     if args.test_email:
         send_email("BG3 Mod Alert – test", "If you see this, email is configured.")
@@ -56,9 +175,9 @@ def main():
                 time.sleep(args.interval_mins * 60)
         else:
             run_check()
-    except NotImplementedError as e:
-        print(str(e))
+    except RuntimeError as e:
+        print(f"Error: {e}")
+
 
 if __name__ == "__main__":
     main()
-


### PR DESCRIPTION
## Summary
Implements a **PS5-only** mod count using mod.io and stabilizes the watcher so we don’t send “ghost” increase emails. Previously we sometimes read an **unfiltered** total (all platforms), which dwarfed the PS5 count and triggered false alerts. We now query `/games/{id}/mods` with `X-Modio-Platform: ps5` and **never** fall back to unfiltered stats.

## What changed
- `src/mod_alert.py`
  - Load `.env` at startup (repo root).
  - `--find-game <name>` helper to discover BG3 game ID/slug.
  - **Strict `get_mod_count()`**:
    - Accepts slug or numeric ID; resolves slug → ID.
    - Sends `X-Modio-Platform: ps5`.
    - Tries both hosts: `https://g-1.modapi.io/v1` then `https://api.mod.io/v1`.
    - Reads `result_total` from `/games/{id}/mods` (page `_limit=1`).
    - **No unfiltered fallback**; raises on failure.
  - `run_check()`:
    - Returns early on fetch errors (does **not** update baseline or email).
    - Updates `state.json` and (optionally) prints `PS5 count = N`.
  - CLI flags: `--baseline`, `--interval-mins`, `--test-email`, `--find-game`.
- `src/mailer.py` (earlier step): loads `.env`, TLS OK on macOS.
- `src/state.py` (earlier step): JSON load/save helpers.
- `.gitignore`: ensure `.env` ignored.
- `.env.example`: placeholders only (no secrets).

## Why
- Prevent false positives when the API returns all-platform totals.
- Make local runs & VS Code runs reliable.
- Keep baseline sane and only email when the **PS5** total increases.

## How to run (repo root, venv active)
```bash
# one-time: find the game and set .env
python -m src.mod_alert --find-game baldur         # shows: 6715  Baldur's Gate 3 (slug: baldursgate3)
# in .env: MODIO_GAME_ID=baldursgate3, MODIO_PLATFORM=ps5

# set a baseline (use the real PS5 number if you know it)
python -m src.mod_alert --baseline 771

# run once (prints PS5 count, updates state.json)
python -m src.mod_alert

# loop every 30m
python -m src.mod_alert --interval-mins 30

# test email
python -m src.mod_alert --test-email
